### PR TITLE
Don't strip XML in <methodCall>

### DIFF
--- a/src/XmlRpc.php
+++ b/src/XmlRpc.php
@@ -83,7 +83,9 @@ final class XmlRpc
     public static function xmlrpc_decode($xml, $encoding = "iso-8859-1")
     {
         $encoder = new Encoder();
-        if (strpos($xml, '<methodResponse>') === false) {
+        if (strpos($xml, '<methodResponse>') === false
+          && strpos($xml, '<methodCall>') === false
+        ) {
             // strip out unnecessary xml in case we're deserializing a single param.
             // in case of a complete response, we do not have to strip anything
             // please note that the test below has LARGE space for improvement (eg. it might trip on xml comments...)


### PR DESCRIPTION
We have code that calls `xmlrpc_decode()` on an XML-RPC request to analyze it.
It works correctly with the native function but the polyfill breaks the XML and causes a mismatched tag error.

Adding a condition to not manipulate the XML ` <methodCall>` seems to fix the error.